### PR TITLE
Add client-side config loader

### DIFF
--- a/assets/js/config-loader.js
+++ b/assets/js/config-loader.js
@@ -1,0 +1,38 @@
+let siteConfig = {};
+
+function applyConfig() {
+  if (!siteConfig) return;
+
+  const authorName = document.querySelector('#author-name');
+  if (authorName) authorName.textContent = siteConfig.authorName;
+
+  const navAuthor = document.querySelector('#nav-author-name');
+  if (navAuthor) navAuthor.textContent = siteConfig.authorName;
+
+  const academicEmail = document.querySelector('#academic-email');
+  if (academicEmail) academicEmail.textContent = siteConfig.academicEmail;
+
+  const industryEmail = document.querySelector('#industry-email');
+  if (industryEmail) industryEmail.textContent = siteConfig.industryEmail;
+
+  const footerTitle = document.querySelector('#footer-site-title');
+  if (footerTitle) footerTitle.textContent = siteConfig.siteTitle;
+
+  if (siteConfig.siteTitle) {
+    document.title = siteConfig.siteTitle;
+  }
+}
+
+function loadConfig() {
+  return fetch('site-config.json')
+    .then(response => response.json())
+    .then(config => {
+      siteConfig = config;
+      applyConfig();
+      return config;
+    })
+    .catch(err => console.error('Failed to load site config', err));
+}
+
+window.siteConfigReady = loadConfig();
+window.applyConfig = applyConfig;

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -69,6 +69,9 @@ document.addEventListener("DOMContentLoaded", function() {
       .then(html => {
         navInclude.innerHTML = html;
         setupNavToggle();
+        if (window.siteConfigReady && window.applyConfig) {
+          window.siteConfigReady.then(() => window.applyConfig());
+        }
       });
   }
   const footerInclude = document.getElementById('footer-include');
@@ -80,6 +83,9 @@ document.addEventListener("DOMContentLoaded", function() {
         // Remove preloader after footer is injected (if present)
         const preloader = document.getElementById('preloader');
         if (preloader) preloader.remove();
+        if (window.siteConfigReady && window.applyConfig) {
+          window.siteConfigReady.then(() => window.applyConfig());
+        }
       });
   }
 

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -70,7 +70,12 @@ document.addEventListener("DOMContentLoaded", function() {
         navInclude.innerHTML = html;
         setupNavToggle();
         if (window.siteConfigReady && window.applyConfig) {
-          window.siteConfigReady.then(() => window.applyConfig());
+          window.siteConfigReady.then(() => {
+            window.applyConfig();
+            document.dispatchEvent(new Event('navigationLoaded'));
+          });
+        } else {
+          document.dispatchEvent(new Event('navigationLoaded'));
         }
       });
   }
@@ -84,7 +89,12 @@ document.addEventListener("DOMContentLoaded", function() {
         const preloader = document.getElementById('preloader');
         if (preloader) preloader.remove();
         if (window.siteConfigReady && window.applyConfig) {
-          window.siteConfigReady.then(() => window.applyConfig());
+          window.siteConfigReady.then(() => {
+            window.applyConfig();
+            document.dispatchEvent(new Event('footerLoaded'));
+          });
+        } else {
+          document.dispatchEvent(new Event('footerLoaded'));
         }
       });
   }

--- a/footer.html
+++ b/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="copyright text-center">
         <p>© <span>Copyright</span>
-          <strong class="px-1 sitename">Portfolio</strong>
+          <strong class="px-1 sitename" id="footer-site-title"></strong>
           <span>All Rights Reserved</span>
         </p>
       </div>

--- a/footer.html
+++ b/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="copyright text-center">
         <p>© <span>Copyright</span>
-          <strong class="px-1 sitename" id="footer-site-title"></strong>
+          <strong class="px-1 sitename" id="footer-site-title">Portfolio</strong>
           <span>All Rights Reserved</span>
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
   <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
 
   <!-- Custom JS Files -->
+  <script src="assets/js/config-loader.js" defer></script>
   <script src="assets/js/index.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
 </head>
@@ -86,7 +87,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <span class="typed-cursor typed-cursor--blink" aria-hidden="true"></span>
             <span class="typed-cursor typed-cursor--blink" aria-hidden="true"></span>
           </p>
-          <h2>Morgan A Vickery, PhD</h2>
+          <h2 id="author-name"></h2>
           <p class="emphasize">I am on the job market seeking TT Assistant Professorships in <em>Learning
               Sciences, Instructional Design, </em>and/or <em>Learning Technologies.</em></p>
         </div>

--- a/navigation.html
+++ b/navigation.html
@@ -3,7 +3,7 @@
   <div class="profile-img">
     <img src="assets/img/profile headshot.png" alt="" class="img-fluid rounded-circle">
   </div>
-  <h1 class="sitename">Morgan A Vickery</h1>
+  <h1 id="nav-author-name" class="sitename"></h1>
   <div class="social-links text-center">
     <a href="https://bsky.app/profile/morganavickery.bsky.social" class="social-button">
       <img src="assets/img/icons/icon_bluesky.png" alt="BlueSky Icon" class="social-icon">
@@ -33,10 +33,10 @@
   </nav>
   <div class="contact-container">
     <p><em>for academic communications</em>
-      <strong>moravick@iu.edu</strong>
+      <strong id="academic-email"></strong>
     </p>
     <p><em>for industry communications</em>
-      <strong>morganavickery@gmail.com</strong>
+      <strong id="industry-email"></strong>
     </p>
   </div>
 </header>

--- a/site-config.json
+++ b/site-config.json
@@ -1,0 +1,6 @@
+{
+  "authorName": "Morgan A Vickery, PhD",
+  "siteTitle": "Portfolio",
+  "academicEmail": "moravick@iu.edu",
+  "industryEmail": "morganavickery@gmail.com"
+}


### PR DESCRIPTION
## Summary
- add config loader that fetches `site-config.json` and injects author/contact details into the DOM
- wire navigation/footer loader to reapply config after fragments are inserted
- place config placeholders in `index.html`, `navigation.html`, and `footer.html`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68adfec4c748832eb96095064150a3a6