### PR TITLE
Add centralized site config file for easy customization

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -69,6 +69,7 @@ document.addEventListener("DOMContentLoaded", function() {
       .then(html => {
         navInclude.innerHTML = html;
         setupNavToggle();
+        document.dispatchEvent(new Event('navigationLoaded'));
       });
   }
   const footerInclude = document.getElementById('footer-include');
@@ -80,6 +81,7 @@ document.addEventListener("DOMContentLoaded", function() {
         // Remove preloader after footer is injected (if present)
         const preloader = document.getElementById('preloader');
         if (preloader) preloader.remove();
+        document.dispatchEvent(new Event('footerLoaded'));
       });
   }
 

--- a/assets/js/site-config.js
+++ b/assets/js/site-config.js
@@ -1,0 +1,69 @@
+function stripComments(str) {
+  return str.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '').trim();
+}
+
+let siteConfig = null;
+
+async function fetchSiteConfig() {
+  try {
+    const res = await fetch('site-config.json');
+    const text = await res.text();
+    siteConfig = JSON.parse(stripComments(text));
+    applySiteConfig();
+  } catch (err) {
+    console.error('Failed to load site-config.json', err);
+  }
+}
+
+function applySiteConfig() {
+  if (!siteConfig) return;
+
+  if (siteConfig.name) {
+    const currentTitle = document.title;
+    if (!currentTitle || currentTitle === 'Portfolio' || currentTitle === siteConfig.name) {
+      document.title = siteConfig.name;
+    } else if (!currentTitle.includes(siteConfig.name)) {
+      document.title = `${currentTitle} - ${siteConfig.name}`;
+    }
+  }
+
+  const navName = document.querySelector('#navigation .sitename');
+  if (navName && siteConfig.name) navName.textContent = siteConfig.name;
+
+  const heroName = document.getElementById('site-name');
+  if (heroName && siteConfig.name) heroName.textContent = siteConfig.name;
+
+  const tagline = document.getElementById('site-tagline');
+  if (tagline && siteConfig.tagline) tagline.textContent = siteConfig.tagline;
+
+  const aboutText = document.getElementById('about-text');
+  if (aboutText && siteConfig.about) aboutText.textContent = siteConfig.about;
+
+  if (siteConfig.social) {
+    const socialMap = {
+      bluesky: 'social-bluesky',
+      twitter: 'social-twitter',
+      google_scholar: 'social-google-scholar',
+      github: 'social-github',
+      linkedin: 'social-linkedin'
+    };
+    Object.entries(socialMap).forEach(([key, id]) => {
+      const link = document.getElementById(id);
+      if (link && siteConfig.social[key]) link.href = siteConfig.social[key];
+    });
+  }
+
+  if (siteConfig.contact) {
+    const academic = document.getElementById('contact-academic');
+    if (academic && siteConfig.contact.academic) academic.textContent = siteConfig.contact.academic;
+    const industry = document.getElementById('contact-industry');
+    if (industry && siteConfig.contact.industry) industry.textContent = siteConfig.contact.industry;
+  }
+
+  const footerName = document.querySelector('#footer .sitename');
+  if (footerName && siteConfig.name) footerName.textContent = siteConfig.name;
+}
+
+document.addEventListener('DOMContentLoaded', fetchSiteConfig);
+document.addEventListener('navigationLoaded', applySiteConfig);
+document.addEventListener('footerLoaded', applySiteConfig);

--- a/database.html
+++ b/database.html
@@ -41,6 +41,7 @@
   <!-- Custom JS Files -->
   <script src="assets/js/main.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
+  <script src="assets/js/site-config.js" defer></script>
   <script src="assets/js/database.js" defer></script>
 </head>
 

--- a/footer.html
+++ b/footer.html
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="copyright text-center">
         <p>© <span>Copyright</span>
-          <strong class="px-1 sitename">Portfolio</strong>
+          <strong class="px-1 sitename" id="footer-site-name">Portfolio</strong>
           <span>All Rights Reserved</span>
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
   <!-- Custom JS Files -->
   <script src="assets/js/index.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
+  <script src="assets/js/site-config.js" defer></script>
 </head>
 
 <!-- Google Analytics Tag -->
@@ -86,8 +87,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <span class="typed-cursor typed-cursor--blink" aria-hidden="true"></span>
             <span class="typed-cursor typed-cursor--blink" aria-hidden="true"></span>
           </p>
-          <h2>Morgan A Vickery, PhD</h2>
-          <p class="emphasize">I am on the job market seeking TT Assistant Professorships in <em>Learning
+          <h2 id="site-name">Morgan A Vickery, PhD</h2>
+          <p class="emphasize" id="site-tagline">I am on the job market seeking TT Assistant Professorships in <em>Learning
               Sciences, Instructional Design, </em>and/or <em>Learning Technologies.</em></p>
         </div>
       </div>
@@ -102,7 +103,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
       <div class="content-container">
         <div class="about-container">
-          <p>I am an aspiring learning scientist and experience designer with dreams of designing enabling, critical,
+          <p id="about-text">I am an aspiring learning scientist and experience designer with dreams of designing enabling, critical,
             and multimodal learning environments that recognize and honor youth's bodies.</p>
         </div>
         <div class="about-list">

--- a/navigation.html
+++ b/navigation.html
@@ -3,21 +3,21 @@
   <div class="profile-img">
     <img src="assets/img/profile headshot.png" alt="" class="img-fluid rounded-circle">
   </div>
-  <h1 class="sitename">Morgan A Vickery</h1>
+  <h1 class="sitename" id="nav-site-name">Morgan A Vickery</h1>
   <div class="social-links text-center">
-    <a href="https://bsky.app/profile/morganavickery.bsky.social" class="social-button">
+    <a id="social-bluesky" href="https://bsky.app/profile/morganavickery.bsky.social" class="social-button">
       <img src="assets/img/icons/icon_bluesky.png" alt="BlueSky Icon" class="social-icon">
     </a>
-    <a href="https://twitter.com/_moravick" class="social-button">
+    <a id="social-twitter" href="https://twitter.com/_moravick" class="social-button">
       <img src="assets/img/icons/icon_twitter.png" alt="Twitter Icon" class="social-icon">
     </a>
-    <a href="https://scholar.google.com/citations?hl=en&user=k8qDnxsAAAAJ&view_op=list_works&sortby=pubdate" class="social-button">
+    <a id="social-google-scholar" href="https://scholar.google.com/citations?hl=en&user=k8qDnxsAAAAJ&view_op=list_works&sortby=pubdate" class="social-button">
       <img src="assets/img/icons/icon_gscholar.png" alt="Google Scholar Icon" class="social-icon">
     </a>
-    <a href="https://github.com/moravick" class="social-button">
+    <a id="social-github" href="https://github.com/moravick" class="social-button">
       <img src="assets/img/icons/icon_github.png" alt="GitHub Icon" class="social-icon">
     </a>
-    <a href="https://www.linkedin.com/in/morganavickery/" class="social-button">
+    <a id="social-linkedin" href="https://www.linkedin.com/in/morganavickery/" class="social-button">
       <img src="assets/img/icons/icon_linkedin.png" alt="LinkedIn Icon" class="social-icon">
     </a>
   </div>
@@ -33,10 +33,10 @@
   </nav>
   <div class="contact-container">
     <p><em>for academic communications</em>
-      <strong>moravick@iu.edu</strong>
+      <strong id="contact-academic">moravick@iu.edu</strong>
     </p>
     <p><em>for industry communications</em>
-      <strong>morganavickery@gmail.com</strong>
+      <strong id="contact-industry">morganavickery@gmail.com</strong>
     </p>
   </div>
 </header>

--- a/resources.html
+++ b/resources.html
@@ -41,6 +41,7 @@
   <!-- Custom JS Files -->
   <script src="assets/js/index.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
+  <script src="assets/js/site-config.js" defer></script>
     <!-- <script src="assets/js/resources.js" defer></script> -->
 
 </head>

--- a/site-config.json
+++ b/site-config.json
@@ -1,0 +1,28 @@
+{
+  // Display name for the site owner
+  "name": "Jane Doe",
+  // Short tagline shown on the homepage hero section
+  "tagline": "Researcher, educator, and designer",
+  // Short blurb for the About section on the home page
+  "about": "I am an aspiring learning scientist and experience designer with dreams of designing enabling, critical, and multimodal learning environments that recognize and honor youths' bodies.",
+  // Social media profile links
+  "social": {
+    // Link to your Bluesky profile
+    "bluesky": "https://bsky.app/profile/example.bsky.social",
+    // Link to your Twitter profile
+    "twitter": "https://twitter.com/example",
+    // Link to your Google Scholar page
+    "google_scholar": "https://scholar.google.com/",
+    // Link to your GitHub profile
+    "github": "https://github.com/example",
+    // Link to your LinkedIn profile
+    "linkedin": "https://www.linkedin.com/in/example/"
+  },
+  // Contact email addresses
+  "contact": {
+    // For academic communications
+    "academic": "academic@example.edu",
+    // For industry communications
+    "industry": "industry@example.com"
+  }
+}


### PR DESCRIPTION
## Summary
- centralize editable text and links in new `site-config.json`
- load configuration dynamically across pages
- mark navigation and footer elements for automatic updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adfec225c4832e84df18ea6deb2932