### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,44 @@ This website serves multiple roles:
 * [Google Fonts](https://fonts.google.com/)
 * **Custom CSS/JS**: `assets/css/*.css`, `assets/js/*.js`
 
+## 🛠️ Setup
+
+1. **Update `site-config.json`**
+   - Located at the project root.
+   - Replace placeholder values with your own site details.
+   - **Before**
+   ```json
+   {
+     "siteTitle": "Morgan A Vickery",
+     "tagline": "Learning Scientist"
+   }
+   ```
+   **After**
+   ```json
+   {
+     "siteTitle": "Jane Doe",
+     "tagline": "Data Scientist"
+   }
+   ```
+   - Ensure the JSON syntax stays valid (use double quotes and commas).
+
+2. **Replace images and data**
+   - Swap images in `assets/img/` with your own files.
+   - Replace `assets/uploads/database.csv` with your data while keeping the header row.
+
+3. **Preview locally**
+   ```bash
+   python3 -m http.server
+   ```
+   Visit `http://localhost:8000` to view the site.
+
+### Common mistakes
+
+- Missing quotes or trailing commas in `site-config.json`.
+- Renaming images without updating their paths in the HTML/CSS.
+- Removing the header row from `database.csv`.
+
+
 ## 🎨 Theme Attribution
 
 


### PR DESCRIPTION
## Summary
- document how to customize `site-config.json` with before/after example
- explain replacing images and the publications CSV
- add notes on local preview and common JSON mistakes

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (fails: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68adfecbd450832e87078d42c50e7c95