### PR TITLE
Ensure config applied before dispatching navigation events

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -68,6 +68,11 @@ document.addEventListener("DOMContentLoaded", function() {
       .then(response => response.text())
       .then(html => {
         navInclude.innerHTML = html;
+        if (typeof applyConfig === 'function') {
+          applyConfig();
+        } else if (typeof applySiteConfig === 'function') {
+          applySiteConfig();
+        }
         setupNavToggle();
         document.dispatchEvent(new Event('navigationLoaded'));
       });
@@ -78,6 +83,11 @@ document.addEventListener("DOMContentLoaded", function() {
       .then(response => response.text())
       .then(html => {
         footerInclude.innerHTML = html;
+        if (typeof applyConfig === 'function') {
+          applyConfig();
+        } else if (typeof applySiteConfig === 'function') {
+          applySiteConfig();
+        }
         // Remove preloader after footer is injected (if present)
         const preloader = document.getElementById('preloader');
         if (preloader) preloader.remove();


### PR DESCRIPTION
## Summary
- Load `navigation.html` and `footer.html` fragments then apply site configuration before firing load events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae02f71684832e902e7e4311a95f76