### PR TITLE
Ensure config loads before navigation scripts

### DIFF
--- a/database.html
+++ b/database.html
@@ -39,6 +39,7 @@
   <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
 
   <!-- Custom JS Files -->
+  <script src="assets/js/config-loader.js" defer></script>
   <script src="assets/js/main.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
   <script src="assets/js/site-config.js" defer></script>

--- a/resources.html
+++ b/resources.html
@@ -39,6 +39,7 @@
   <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
 
   <!-- Custom JS Files -->
+  <script src="assets/js/config-loader.js" defer></script>
   <script src="assets/js/index.js" defer></script>
   <script src="assets/js/navigation.js" defer></script>
   <script src="assets/js/site-config.js" defer></script>


### PR DESCRIPTION
## Summary
- Load `config-loader.js` ahead of other custom scripts on database and resources pages.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/academic-website-template/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ae075cb724832e93f9bd36aa969235