### PR TITLE
Remove duplicate decodeEntities and load call

### DIFF
--- a/assets/js/database.js
+++ b/assets/js/database.js
@@ -154,12 +154,3 @@ function displayCards() {
   // Initialize database loading
   loadDatabase();
 });
-
-  function decodeEntities(encodedString) {
-    let textarea = document.createElement("textarea");
-    textarea.innerHTML = encodedString;
-    return textarea.value;
-  }
-
-  // Initialize
-  loadDatabase();


### PR DESCRIPTION
## Summary
- Drop redundant decodeEntities helper outside DOMContentLoaded handler.
- Ensure database load function is invoked only once inside handler.

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae099f5d14832e9ebaf91b6e8975ef