### PR TITLE
Make social links configurable

### DIFF
--- a/assets/js/site-config.js
+++ b/assets/js/site-config.js
@@ -49,15 +49,46 @@ function applySiteConfig() {
     };
     Object.entries(socialMap).forEach(([key, id]) => {
       const link = document.getElementById(id);
-      if (link && siteConfig.social[key]) link.href = siteConfig.social[key];
+      if (!link) return;
+      const url = siteConfig.social[key];
+      if (url) {
+        link.href = url;
+        link.style.display = '';
+      } else {
+        link.style.display = 'none';
+      }
+    });
+  } else {
+    ['social-bluesky', 'social-twitter', 'social-google-scholar', 'social-github', 'social-linkedin'].forEach(id => {
+      const link = document.getElementById(id);
+      if (link) link.style.display = 'none';
     });
   }
 
   if (siteConfig.contact) {
     const academic = document.getElementById('contact-academic');
-    if (academic && siteConfig.contact.academic) academic.textContent = siteConfig.contact.academic;
+    if (academic) {
+      if (siteConfig.contact.academic) {
+        academic.textContent = siteConfig.contact.academic;
+        academic.parentElement.style.display = '';
+      } else {
+        academic.parentElement.style.display = 'none';
+      }
+    }
     const industry = document.getElementById('contact-industry');
-    if (industry && siteConfig.contact.industry) industry.textContent = siteConfig.contact.industry;
+    if (industry) {
+      if (siteConfig.contact.industry) {
+        industry.textContent = siteConfig.contact.industry;
+        industry.parentElement.style.display = '';
+      } else {
+        industry.parentElement.style.display = 'none';
+      }
+    }
+  } else {
+    ['contact-academic', 'contact-industry'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.parentElement.style.display = 'none';
+    });
   }
 
   const footerName = document.querySelector('#footer .sitename');

--- a/navigation.html
+++ b/navigation.html
@@ -5,19 +5,19 @@
   </div>
   <h1 class="sitename" id="nav-site-name">Morgan A Vickery</h1>
   <div class="social-links text-center">
-    <a id="social-bluesky" href="https://bsky.app/profile/morganavickery.bsky.social" class="social-button">
+    <a id="social-bluesky" href="#" class="social-button">
       <img src="assets/img/icons/icon_bluesky.png" alt="BlueSky Icon" class="social-icon">
     </a>
-    <a id="social-twitter" href="https://twitter.com/_moravick" class="social-button">
+    <a id="social-twitter" href="#" class="social-button">
       <img src="assets/img/icons/icon_twitter.png" alt="Twitter Icon" class="social-icon">
     </a>
-    <a id="social-google-scholar" href="https://scholar.google.com/citations?hl=en&user=k8qDnxsAAAAJ&view_op=list_works&sortby=pubdate" class="social-button">
+    <a id="social-google-scholar" href="#" class="social-button">
       <img src="assets/img/icons/icon_gscholar.png" alt="Google Scholar Icon" class="social-icon">
     </a>
-    <a id="social-github" href="https://github.com/moravick" class="social-button">
+    <a id="social-github" href="#" class="social-button">
       <img src="assets/img/icons/icon_github.png" alt="GitHub Icon" class="social-icon">
     </a>
-    <a id="social-linkedin" href="https://www.linkedin.com/in/morganavickery/" class="social-button">
+    <a id="social-linkedin" href="#" class="social-button">
       <img src="assets/img/icons/icon_linkedin.png" alt="LinkedIn Icon" class="social-icon">
     </a>
   </div>
@@ -33,10 +33,10 @@
   </nav>
   <div class="contact-container">
     <p><em>for academic communications</em>
-      <strong id="contact-academic">moravick@iu.edu</strong>
+      <strong id="contact-academic"></strong>
     </p>
     <p><em>for industry communications</em>
-      <strong id="contact-industry">morganavickery@gmail.com</strong>
+      <strong id="contact-industry"></strong>
     </p>
   </div>
 </header>

--- a/site-config.json
+++ b/site-config.json
@@ -5,24 +5,26 @@
   "tagline": "Researcher, educator, and designer",
   // Short blurb for the About section on the home page
   "about": "I am an aspiring learning scientist and experience designer with dreams of designing enabling, critical, and multimodal learning environments that recognize and honor youths' bodies.",
-  // Social media profile links
+  // Social media profile links control the icons in the navigation.
+  // Remove a URL or leave it blank to hide its icon.
   "social": {
-    // Link to your Bluesky profile
+    // Bluesky icon
     "bluesky": "https://bsky.app/profile/example.bsky.social",
-    // Link to your Twitter profile
+    // Twitter icon
     "twitter": "https://twitter.com/example",
-    // Link to your Google Scholar page
+    // Google Scholar icon
     "google_scholar": "https://scholar.google.com/",
-    // Link to your GitHub profile
+    // GitHub icon
     "github": "https://github.com/example",
-    // Link to your LinkedIn profile
+    // LinkedIn icon
     "linkedin": "https://www.linkedin.com/in/example/"
   },
-  // Contact email addresses
+  // Contact email addresses displayed in the navigation footer.
+  // Remove an address or leave it blank to hide that line.
   "contact": {
-    // For academic communications
+    // Academic email line
     "academic": "academic@example.edu",
-    // For industry communications
+    // Industry email line
     "industry": "industry@example.com"
   }
 }


### PR DESCRIPTION
## Summary
- remove hard-coded links from navigation
- hide social icons or contact lines when config values are missing
- document configurable social/contact fields in site-config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0a707748832ea857c68e9436fbbb