### PR TITLE
docs: expand beginner-friendly readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,101 @@
-# Morgan A Vickery – Academic Portfolio Website
+# Academic Portfolio Website Template
 
-This is the personal website and academic portfolio of **Morgan A Vickery, PhD**, designed to showcase her research, publications, teaching materials, and professional experiences. The site functions as an online CV, resource hub, and interactive archive of open-access academic tools and technologies.
+A simple website for showcasing your academic work. Everything is plain HTML, CSS, and JavaScript so you can host it anywhere (such as GitHub Pages).
 
-## 🌐 Live Site
+## 1. Create Your Own Copy
 
-[morganavickery.com](https://morganavickery.com)
+*GitHub* is a website for storing and sharing files. A *repository* (or *repo*) is just a folder of files on GitHub.
 
-## 🎯 Purpose
+1. Make a free account at [github.com](https://github.com/).
+2. Click **Fork** to create your own copy of this repo. Forking means "make my own version on GitHub".
+3. To host your site at `https://YOURNAME.github.io`, go to your fork’s **Settings → General** page and rename the repo to `YOURNAME.github.io`.
+4. Want the files on your computer? Click the green **Code** button → **Download ZIP** and unzip it. That download is sometimes called a *clone*.
+5. You can edit files directly on GitHub (open a file and click the ✏️ icon) or drag‑and‑drop new files with the **Upload files** button. No command line is required.
 
-This website serves multiple roles:
+*GitHub Pages* is GitHub’s free service for turning a repo into a public website. You will use it in Step 7.
 
-* Present Morgan A Vickery’s academic background, research interests, and publications.
-* Host interactive tools such as the **Publications Database** and **Open-Access Resources**.
-* Provide access to professional documents like a CV.
-* Highlight teaching resources and accessibility-centered design work.
+## 2. Overview of the Repository
 
-## 🗂️ Pages and Features
+You mainly edit small text files that describe your content. Other files handle layout and style automatically.
 
-| Page | File | Description |
-|----|----|----|
-| Home | `index.html` | Landing page with sections on research, projects, technologies, and CV. Optional Google Analytics. |
-| Publications | `database.html` | Dynamic, card-based rendering of Morgan’s publication database from a CSV data source. |
-| Open-Access Resources | `resources.html` | A curated list of publicly available learning and teaching tools, documents, and templates. |
-| Navigation | `navigation.html` | Sidebar-based navigation with links to key sections and social media profiles. |
-| Footer | `footer.html` | Standardized footer used across pages. |
+| Goal | Edit this file | Files that make it work (ignore these) | Where it shows up |
+| --- | --- | --- | --- |
+| Site title, tagline, contact links | `site-config.json` | `assets/js/site-config.js` | every page |
+| Menu text and order | `navigation.html` | `assets/js/navigation.js`, `assets/css/navigation.css` | top navigation bar |
+| Footer text | `footer.html` | `assets/css/index.css` | bottom of every page |
+| Home page sections (About, Research, Publications, Projects, Technologies) | data files in `assets/data` | `index.html`, `assets/js/index-content.js`, `assets/css/index.css` | home page |
+| Resources page items | `assets/data/resources.json` | `resources.html`, `assets/js/resources.js`, `assets/css/resources.css` | resources page |
+| Full publications list | `assets/data/database.csv` | `database.html`, `assets/js/database.js`, `assets/css/database.css` | publications page |
+| Photos (profile, hero) | images in `assets/img` | `index.html`, `navigation.html` | home page & menu |
 
-## 🔧 Tech Stack
+## 3. Replace Text, Data, and Images
 
-* **HTML5**, **CSS3**, **JavaScript (Vanilla)**
-* [Bootstrap 5](https://getbootstrap.com/)
-* [AOS (Animate on Scroll)](https://michalsnik.github.io/aos/)
-* [Glightbox](https://biati-digital.github.io/glightbox/)
-* [Swiper.js](https://swiperjs.com/)
-* [Google Fonts](https://fonts.google.com/)
-* **Custom CSS/JS**: `assets/css/*.css`, `assets/js/*.js`
+All editable data files live in `assets/data`, and images live in `assets/img`.
 
-## 🛠️ Setup
+### Data file cheat sheet
 
-1. **Update `site-config.json`**
-   - Located at the project root.
-   - Replace placeholder values with your own site details.
-   - Top-level fields include:
-     - `name`: Display name for the site owner.
-    - `tagline`: Short tagline shown on the homepage hero section.
-    - `typedItems`: Array of phrases for the homepage typing animation.
-    - `social`: Links for social media icons (keys: `bluesky`, `twitter`, `google_scholar`, `github`, `linkedin`).
-     - `contact`: Email addresses shown in the navigation footer (`academic`, `industry`).
-     - `analyticsId`: Google Analytics ID (e.g., `G-XXXXXXXXXX`). Remove this field to disable tracking.
-   - Example:
-   ```jsonc
-   {
-     // Display name for the site owner
-     "name": "Jane Doe",
-     // Short tagline shown on the homepage hero section
-     "tagline": "Data Scientist",
-     "typedItems": ["Scientist", "Teacher"],
-     // Social media profile links. Remove a URL to hide its icon.
-     "social": {
-       "bluesky": "https://bsky.app/profile/example.bsky.social",
-       "twitter": "https://twitter.com/example",
-       "google_scholar": "https://scholar.google.com/",
-       "github": "https://github.com/example",
-       "linkedin": "https://www.linkedin.com/in/example/"
-     },
-     // Contact email addresses displayed in the navigation footer
-     "contact": {
-       "academic": "academic@example.edu",
-       "industry": "industry@example.com"
-     },
-     "analyticsId": "G-XXXXXXXXXX"
-   }
-   ```
-   - `site-config.json` supports `//` comments for readability. Tools that require strict JSON may fail to parse these comments; remove them or use a friendlier format like YAML and convert back to JSON before deployment.
+| File | What it controls | Example snippet | Notes |
+| --- | --- | --- | --- |
+| `site-config.json` | Name, tagline, social links | `{"name":"Your Name"}` | Leave a link blank to hide its icon. |
+| `about.json` | Short bio and list of roles | `{ "text": "One sentence.", "roles": [{"role": "PhD Student", "institution": "Example Univ."}] }` | |
+| `research.json` | Topics you study | `{ "topics": ["Topic one", "Topic two"] }` | |
+| `publications.json` | A few highlighted citations on the home page | `{ "publications": [{"citation": "Author (2024)", "link": "https://..."}] }` | Use for a small set of featured works. |
+| `projects.json` | Research projects | `{ "featured": [{"title": "Big Project"}], "other": [{"title": "Small Project"}] }` | `featured` shows large cards; `other` shows a simple list. |
+| `technologies.json` | Tools or software you created | `{ "technologies": [{"title": "Tool", "role": "Developer"}] }` | |
+| `resources.json` | Resource links page | `[ {"title": "Template", "description": "What it is", "link": "https://..."} ]` | Each item needs `title`, `description`, `link`. |
+| `database.csv` | Full publications list | `date,"authors",title,venue,link`<br>`2024,"A. Author",Example Paper,Conf,https://...` | Keep the header exactly as shown. |
 
-2. **Replace images and data**
-   - Swap images in `assets/img/` with your own files.
-   - Replace `assets/uploads/database.csv` with your data while keeping the header row.
+### Upload your own files
+- **CV** – replace `assets/data/cv.pdf` with your PDF.
+- **Profile picture** – replace `assets/img/profile headshot.png` (keep the name or update `index.html` and `navigation.html`).
+- **Hero image** – replace `assets/img/rene-bohmer-YeUVDKZWSZ4-unsplash.jpg` or change the file name in `index.html`.
+- **Full publications list** – upload your own `database.csv` with the same header.
 
-3. **Add resources**
-   - Edit `assets/data/resources.json` to manage entries shown on `resources.html`.
-   - Each item requires a `title`, `description`, and `link`. Optional fields like `meta`, `type`, or `embed` add extra details or custom layouts.
-   - Example:
-     ```json
-     [
-       {
-         "title": "Example Resource",
-         "description": "Short summary of the resource.",
-         "link": "https://example.com",
-         "meta": "Optional extra info",
-         "type": "whimsical",
-         "embed": "https://whimsical.com/embed/example"
-       }
-     ]
-     ```
+## 4. File Naming Tips
+- Keep data file names the same (`about.json`, `projects.json`, etc.).
+- For new images, use simple names like `my-photo.jpg` (lowercase letters, numbers, dashes). If you change a file name, update any HTML or JSON that refers to it.
+- The CSV must stay named `database.csv` and include the header row.
 
-4. **Customize home page sections**
-   - Edit JSON files in `assets/data/` to populate the home page:
-     - `about.json`
-     - `research.json`
-     - `publications.json`
-     - `projects.json`
-     - `technologies.json`
+## 5. Remove Sections You Don’t Need
+- To hide a section on the home page, wrap its block in HTML comments in `index.html`:
+  ```html
+  <!--
+  <section id="technologies">
+    ...
+  </section>
+  -->
+  ```
+- Hide its link in `navigation.html` the same way:
+  ```html
+  <!-- <li><a href="#technologies">Technologies</a></li> -->
+  ```
+- If a data file is empty, the section will simply appear blank.
+- Leaving a social or contact link empty in `site-config.json` hides it automatically.
 
-5. **Preview locally**
-   ```bash
-   python3 -m http.server
-   ```
-   Visit `http://localhost:8000` to view the site.
+## 6. Preview the Site Locally
+Double‑click `index.html` to open it in a browser. If some sections look empty, your browser may require a simple local server:
+```bash
+python3 -m http.server
+```
+Then visit `http://localhost:8000` in a browser.
 
-### Common mistakes
+## 7. Make It Live on the Internet
+1. Commit and push your changes to GitHub.
+2. Go to **Settings → Pages** in your repo.
+3. Under **Build and deployment**, choose **Deploy from a branch**.
+4. Select the `main` branch and the `/ (root)` folder, then **Save**.
+5. Wait a minute for GitHub Pages to build your site. Refresh `https://YOURNAME.github.io/` (or `https://YOURNAME.github.io/REPO_NAME/` if you used a different repo name).
 
-- Missing quotes or trailing commas in `site-config.json` (especially after removing comments).
-- Renaming images without updating their paths in the HTML/CSS.
-- Removing the header row from `database.csv`.
+## 8. Use Your Own Domain (Optional)
+If you already own a domain name (like `example.com`), you can point it to your GitHub Pages site.
 
+1. Open the file named `CNAME` in this repo (or create one) and replace its contents with your domain name, e.g. `example.com`.
+2. In the repo’s **Settings → Pages → Custom domain** box, type the same domain name and click **Save**.
+3. At your domain provider’s website, find the DNS settings and create a **CNAME** record that points your domain (or `www` subdomain) to `YOURNAME.github.io`.
+4. DNS changes can take a while—after it updates, your site will appear at your domain.
 
-## 🎨 Theme Attribution
+If you decide not to use a custom domain, delete the `CNAME` file so GitHub Pages uses the default `YOURNAME.github.io` address.
 
-
-This project expands on the [iPortfolio template](https://bootstrapmade.com/iportfolio-bootstrap-portfolio-websites-template/) by **BootstrapMade.com**License: [BootstrapMade License](https://bootstrapmade.com/license/)
-
-## 👩‍🎓 Author Info
-
-**Morgan A Vickery, PhD**
-
-* Learning Scientist, UX Designer, and Educator
-* Contact: `moravick@iu.edu` or `morganavickery@gmail.com`
-
-## 📬 Connect With Me
-
-* [Google Scholar](https://scholar.google.com/citations?user=k8qDnxsAAAAJ)
-* [LinkedIn](https://www.linkedin.com/in/morganavickery/)
-* [GitHub](https://github.com/moravick)
-* [BlueSky](https://bsky.app/profile/morganavickery.bsky.social)
-* [Twitter](https://twitter.com/_moravick)
-
-
----
-
+## 9. Credits
+This template is adapted from the [iPortfolio theme](https://bootstrapmade.com/iportfolio-bootstrap-portfolio-websites-template/) by BootstrapMade.
 


### PR DESCRIPTION
## Summary
- define GitHub terms and forking/downloading steps for newcomers
- add repository overview table and data file cheat sheet, including featured vs. other projects
- document how to hide sections by commenting out HTML blocks and navigation links
- guide users on deploying to GitHub Pages and using a custom domain

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae15fda24c832e9cb24719dab9d5bc