### PR TITLE
Fix hero section fallback content

### DIFF
--- a/assets/js/site-config.js
+++ b/assets/js/site-config.js
@@ -24,6 +24,9 @@ async function fetchSiteConfig() {
     applySiteConfig();
   } catch (err) {
     console.error('Failed to load site-config.json', err);
+    if (typeof initializeTyped === 'function') {
+      initializeTyped();
+    }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -59,9 +59,11 @@
           <img src="assets/img/profile-headshot.png">
         </div>
         <div class="text-container">
-          <p><span class="typed"></span></p>
-          <h2 id="site-name"></h2>
-          <p class="emphasize" id="site-tagline"></p>
+          <p>
+            <span class="typed" data-typed-items="Educator, Researcher, Designer, Advocate">Researcher</span>
+          </p>
+          <h2 id="site-name">Jane Doe</h2>
+          <p class="emphasize" id="site-tagline">Researcher, educator, and designer</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Populate hero section with default name, tagline, and typed items so the page isn’t blank before config loads
- Initialize typed animation even if `site-config.json` fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae21461650832eb7c05ed8fff68568